### PR TITLE
[Test (integration) + Implement] 'infer' PORO collection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   TargetRubyVersion: 2.6
   NewCops: enable
   SuggestExtensions: false
+  Exclude:
+    - 'test/dummy/bin/bundle'
 
 Layout/LineLength:
   Max: 120

--- a/lib/roar_responder/responder.rb
+++ b/lib/roar_responder/responder.rb
@@ -30,7 +30,7 @@ module RoarResponder
     end
 
     def collection?
-      resource.respond_to?(:length)
+      resource.respond_to?(:count)
     end
   end
 end

--- a/test/dummy/app/controllers/concerns/poro_controllable.rb
+++ b/test/dummy/app/controllers/concerns/poro_controllable.rb
@@ -7,10 +7,9 @@ module PoroControllable
     def record_class
       DummyPoro
     end
-  
+
     def attributes
       super.merge(valid: (params[:model][:dummy_string] != 'invalid'))
     end
   end
 end
-

--- a/test/dummy/app/controllers/infer/infer_controller.rb
+++ b/test/dummy/app/controllers/infer/infer_controller.rb
@@ -6,6 +6,10 @@ module Infer
       respond_with find_entity
     end
 
+    def index
+      respond_with collection
+    end
+
     def create
       respond_with new_entity
     end
@@ -14,6 +18,10 @@ module Infer
 
     def find_entity
       record_class.find(params[:id])
+    end
+
+    def collection
+      record_class.all
     end
 
     def new_entity

--- a/test/dummy/app/controllers/infer/poro_controller.rb
+++ b/test/dummy/app/controllers/infer/poro_controller.rb
@@ -3,5 +3,10 @@
 module Infer
   class PoroController < InferController
     include PoroControllable
+
+    def collection
+      array = record_class.all
+      DummyPoros.new(array)
+    end
   end
 end

--- a/test/dummy/app/models/dummy_poros.rb
+++ b/test/dummy/app/models/dummy_poros.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DummyPoros
+  include Enumerable
+  extend ActiveModel::Naming
+
+  def initialize(original_collection)
+    @original_collection = original_collection
+  end
+
+  delegate :each, to: :original_collection
+
+  private
+
+  attr_reader :original_collection
+end

--- a/test/dummy/app/representers/dummy_poros_collection_representer.rb
+++ b/test/dummy/app/representers/dummy_poros_collection_representer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DummyPorosCollectionRepresenter < DummyCollectionRepresenter
+  self.representation_wrap = :dummy_poro_collection_infer
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   namespace 'infer' do
-    resources :poro, only: %i[show create]
+    resources :poro, only: %i[show index create]
   end
 
   namespace 'instance' do

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  namespace 'class_spec' do
-    resources :active_record, only: %i[create index show]
-    resources :mongo, only: %i[create index show]
-    resources :poro, only: %i[create index show]
+  %w[class_spec instance].each do |ns|
+    namespace ns do
+      resources :active_record, only: %i[create index show]
+      resources :mongo, only: %i[create index show]
+      resources :poro, only: %i[create index show]
+    end
   end
 
   namespace 'infer' do
     resources :poro, only: %i[show index create]
-  end
-
-  namespace 'instance' do
-    resources :active_record, only: %i[create index show]
-    resources :mongo, only: %i[create index show]
-    resources :poro, only: %i[create index show]
   end
 end

--- a/test/integration/infer/poro_test.rb
+++ b/test/integration/infer/poro_test.rb
@@ -12,6 +12,22 @@ module Integration
         assert_response_entity JSON.parse(response.body), 'dummy_poro_infer'
       end
 
+      def test_get_collection
+        get infer_poro_index_path, as: :json
+
+        assert_response :ok
+
+        response_collection = JSON.parse(response.body)
+
+        root_wrap = 'dummy_poro_collection_infer'
+
+        assert_self_link(response_collection, root_wrap, '/collection')
+
+        items = response_collection.dig(root_wrap, 'items') || []
+        assert_equal 2, items.length
+        items.each(&method(:assert_response_entity))
+      end
+
       def test_post_entity_success
         post infer_poro_index_path, params: { model: dummy_attrs }, as: :json
 


### PR DESCRIPTION
Part of #11

'respond_with' for a successful 'GET' request of a collection.
The collection here must be a Ruby object that acts as a collection of DummyPoro and that responds to enumerable methods.
This is because a bare Array wouldn't respond to model_name which is necessary here for inferring the representer class.
When the representer_class is specified and not inferred, an Array still
will do.