### PR TITLE
Test (integration) 'representer_class' for the controller being inferred for the model for ORMs (ActiveRecord and Mongoid)

### DIFF
--- a/test/dummy/app/controllers/infer/active_record_controller.rb
+++ b/test/dummy/app/controllers/infer/active_record_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Infer
+  class ActiveRecordController < InferController
+    private
+
+    def record_class
+      DummyActiveRecordModel
+    end
+  end
+end

--- a/test/dummy/app/controllers/infer/mongo_controller.rb
+++ b/test/dummy/app/controllers/infer/mongo_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Infer
+  class MongoController < InferController
+    private
+
+    def record_class
+      DummyMongoModel
+    end
+  end
+end

--- a/test/dummy/app/representers/dummy_active_record_model_collection_representer.rb
+++ b/test/dummy/app/representers/dummy_active_record_model_collection_representer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DummyActiveRecordModelCollectionRepresenter < DummyCollectionRepresenter
+  self.representation_wrap = :dummy_active_record_collection_infer
+end

--- a/test/dummy/app/representers/dummy_active_record_model_representer.rb
+++ b/test/dummy/app/representers/dummy_active_record_model_representer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DummyActiveRecordModelRepresenter < DummyRepresenter
+  self.representation_wrap = :dummy_active_record_infer
+end

--- a/test/dummy/app/representers/dummy_mongo_model_collection_representer.rb
+++ b/test/dummy/app/representers/dummy_mongo_model_collection_representer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DummyMongoModelCollectionRepresenter < DummyCollectionRepresenter
+  self.representation_wrap = :dummy_mongo_collection_infer
+end

--- a/test/dummy/app/representers/dummy_mongo_model_representer.rb
+++ b/test/dummy/app/representers/dummy_mongo_model_representer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DummyMongoModelRepresenter < DummyRepresenter
+  self.representation_wrap = :dummy_mongo_infer
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  %w[class_spec instance].each do |ns|
+  %w[class_spec infer instance].each do |ns|
     namespace ns do
-      resources :active_record, only: %i[create index show]
-      resources :mongo, only: %i[create index show]
-      resources :poro, only: %i[create index show]
+      %i[active_record mongo poro].each do |orm_type|
+        resources orm_type, only: %i[create index show]
+      end
     end
-  end
-
-  namespace 'infer' do
-    resources :poro, only: %i[show index create]
   end
 end

--- a/test/integration/infer/active_record_test.rb
+++ b/test/integration/infer/active_record_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Integration
+  module Infer
+    class ActiveRecordTest < ActionDispatch::IntegrationTest
+      def test_get_entity
+        entity = DummyActiveRecordModel.create(**dummy_attrs)
+
+        get infer_active_record_path(entity), as: :json
+
+        assert_response :ok
+        assert_response_entity JSON.parse(response.body), 'dummy_active_record_infer'
+      end
+
+      def test_get_collection
+        collection_size = 2
+        collection_size.times { DummyActiveRecordModel.create(**dummy_attrs) }
+
+        get infer_active_record_index_path, as: :json
+
+        assert_response :ok
+
+        response_collection = JSON.parse(response.body)
+
+        root_wrap = 'dummy_active_record_collection_infer'
+
+        assert_self_link(response_collection, root_wrap, '/collection')
+
+        items = response_collection.dig(root_wrap, 'items') || []
+        assert_equal collection_size, items.length
+        items.each(&method(:assert_response_entity))
+      end
+
+      def test_post_entity_success
+        post infer_active_record_index_path, params: { model: dummy_attrs }, as: :json
+
+        assert_response :created
+        assert_response_entity JSON.parse(response.body), 'dummy_active_record_infer'
+      end
+
+      def test_post_entity_failure
+        post infer_active_record_index_path, params: { model: dummy_invalid_attrs }, as: :json
+
+        assert_response :unprocessable_entity
+        assert_response_error JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/test/integration/infer/mongoid_test.rb
+++ b/test/integration/infer/mongoid_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Integration
+  module Infer
+    class MongoidTest < ActionDispatch::IntegrationTest
+      def test_get_entity
+        entity = DummyMongoModel.create(**dummy_attrs)
+
+        get infer_mongo_path(entity), as: :json
+
+        assert_response :ok
+        assert_response_entity JSON.parse(response.body), 'dummy_mongo_infer'
+      end
+
+      def test_get_collection
+        collection_size = 2
+        collection_size.times { DummyMongoModel.create(**dummy_attrs) }
+
+        get infer_mongo_index_path, as: :json
+
+        assert_response :ok
+
+        response_collection = JSON.parse(response.body)
+
+        root_wrap = 'dummy_mongo_collection_infer'
+
+        assert_self_link(response_collection, root_wrap, '/collection')
+
+        items = response_collection.dig(root_wrap, 'items') || []
+        assert_equal collection_size, items.length
+        items.each(&method(:assert_response_entity))
+      end
+
+      def test_post_entity_success
+        post infer_mongo_index_path, params: { model: dummy_attrs }, as: :json
+
+        assert_response :created
+        assert_response_entity JSON.parse(response.body), 'dummy_mongo_infer'
+      end
+
+      def test_post_entity_failure
+        post infer_mongo_index_path, params: { model: dummy_invalid_attrs }, as: :json
+
+        assert_response :unprocessable_entity
+        assert_response_error JSON.parse(response.body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of #11

- 'respond_with' for a successful 'GET' request of an entity (Active Record)
- 'respond_with' for a successful 'GET' request of a collection (ActiveRecord::Relation)
- 'respond_with' for a successful 'POST' request of an entity (Active Record)
- 'respond_with' for a failed 'POST' request of an entity (Active Record)
- 'respond_with' for a successful 'GET' request of an entity (Mongo ID)
- 'respond_with' for a successful 'GET' request of a collection (Mongoid::Criteria)
- 'respond_with' for a successful 'POST' request of an entity (Mongo ID)
- 'respond_with' for a failed 'POST' request of an entity (Mongo ID)