### PR TITLE
Test render a model to JSON with default serializer

### DIFF
--- a/test/dummy/app/controllers/default_serialization_controller.rb
+++ b/test/dummy/app/controllers/default_serialization_controller.rb
@@ -2,29 +2,6 @@
 
 class DefaultSerializationController < ApplicationController
   def simple
-    respond_with SimpleClass.new
-  end
-
-  class SimpleClass
-    include ActiveModel::Serializers::JSON
-    include ActiveModel::Conversion
-
-    def initialize
-      @foo = 'bar'
-    end
-
-    attr_reader :foo
-
-    def attributes
-      { 'foo' => 'bar' }
-    end
-
-    def persisted?
-      false
-    end
-
-    def id
-      nil
-    end
+    respond_with SimpleModel.new
   end
 end

--- a/test/dummy/app/controllers/default_serialization_controller.rb
+++ b/test/dummy/app/controllers/default_serialization_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DefaultSerializationController < ApplicationController
+  def simple
+    respond_with SimpleClass.new
+  end
+
+  class SimpleClass
+    include ActiveModel::Serializers::JSON
+    include ActiveModel::Conversion
+
+    def initialize
+      @foo = 'bar'
+    end
+
+    attr_reader :foo
+
+    def attributes
+      { 'foo' => 'bar' }
+    end
+
+    def persisted?
+      false
+    end
+
+    def id
+      nil
+    end
+  end
+end

--- a/test/dummy/app/models/simple_model.rb
+++ b/test/dummy/app/models/simple_model.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class SimpleModel
+  include ActiveModel::Serializers::JSON
+  include ActiveModel::Conversion
+
+  def initialize
+    @foo = 'bar'
+  end
+
+  attr_reader :foo
+
+  def attributes
+    { 'foo' => 'bar' }
+  end
+
+  def persisted?
+    false
+  end
+
+  def id
+    nil
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  get 'default_serialization', to: 'default_serialization#simple'
 end

--- a/test/integration/default_serialization_test.rb
+++ b/test/integration/default_serialization_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Integration
+  class DefaultSerializationTest < ActionDispatch::IntegrationTest
+    def test_default_serialization
+      get default_serialization_path, as: :json
+
+      assert_response :ok
+      expected_response_body = { 'foo' => 'bar' }
+      assert_equal expected_response_body, JSON.parse(response.body)
+    end
+  end
+end


### PR DESCRIPTION
Part of #11 

Test default model.to_json when the inferred representer class does not exist.
The resource of this test also does not need to respond to `model_name`, but apparently, it needs to respond to `to_model` although that it's not for this gem itself but for one of the dependencies.
